### PR TITLE
Add Seedream multi-reference studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+*.log
+.env
+.env.local
+.DS_Store
+frontend/dist/
+frontend/.vite/
+server/node_modules/
+frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
-# seedbox
+# Seedream Studio
+
+A modern web experience for orchestrating multi-reference prompts with [Seedream-4](https://replicate.com/bytedance/seedream-4) on Replicate. The project is split into a Vite + React front-end and an Express-based API proxy that safely forwards uploads to Replicate.
+
+## Features
+
+- **Drag-and-drop gallery** – upload multiple reference images, preview them instantly, and remove any you no longer need.
+- **Per-image guidance** – add a short instruction for every image so Seedream-4 knows exactly what to extract.
+- **Creative brief composer** – craft a primary prompt and optional negative prompt inside an elegant, distraction-free workspace.
+- **Result viewer** – display generated images or videos, with quick links to open the assets in a new tab.
+- **Secure Replicate bridge** – the back-end accepts files via `multipart/form-data`, converts them to data URIs, and forwards them using Replicate’s official SDK.
+
+## Project structure
+
+```text
+frontend/   # Vite + React (TypeScript) client
+server/     # Express API proxy with Replicate integration
+```
+
+## Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   cd frontend && npm install
+   cd ../server && npm install
+   ```
+
+   > ℹ️  If you encounter registry access restrictions, configure `npm` to use a mirror or install the listed packages manually.
+
+2. **Configure environment variables**
+
+   Copy the server example file and fill in your credentials:
+
+   ```bash
+   cd server
+   cp .env.example .env
+   ```
+
+   Required values:
+
+   - `REPLICATE_API_TOKEN` – your Replicate API token.
+   - `SEEDREAM4_MODEL_VERSION` – the fully-qualified model version string (for example, `bytedance/seedream-4:<hash>`).
+
+3. **Run the development servers**
+
+   Start the API proxy:
+
+   ```bash
+   cd server
+   npm run dev
+   ```
+
+   In a second terminal, start the Vite dev server:
+
+   ```bash
+   cd frontend
+   npm run dev
+   ```
+
+   The front-end proxies `/api` requests to `http://localhost:5000` by default. Set `VITE_API_BASE_URL` in `frontend/.env` if you deploy the back-end elsewhere.
+
+4. **Production build**
+
+   ```bash
+   cd frontend
+   npm run build
+   ```
+
+   The compiled assets land in `frontend/dist/`.
+
+## API request flow
+
+1. The React app collects your prompt, negative prompt, and per-image instructions.
+2. Files are sent to the Express server with names encoded as `<uuid>__<original-name>`.
+3. The server converts each image to a `data:` URI, merges your instructions into a structured prompt, and calls Replicate via `replicate.run()`.
+4. Replicate responds with an array of URLs (images or videos) that the front-end displays immediately.
+
+## Notes
+
+- Increase the `multer` limits in `server/index.js` if you need to accept more or larger files.
+- Update `vite.config.ts` proxy settings if your API runs on a different port.
+- Customize the UI theme by editing `frontend/src/App.css`.

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,26 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  plugins: ["@typescript-eslint", "react-refresh"],
+  rules: {
+    "react-refresh/only-export-components": "warn",
+  },
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Seedream Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "seedream-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview --host",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.24",
+    "@types/react-dom": "^18.2.8",
+    "@vitejs/plugin-react": "^4.2.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "eslint": "^8.53.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.4",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,284 @@
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 32px 24px 64px;
+}
+
+.app-header {
+  max-width: 960px;
+  margin: 0 auto 32px;
+  text-align: center;
+}
+
+.app-header h1 {
+  font-size: clamp(2.2rem, 4vw, 2.8rem);
+  margin-bottom: 12px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.app-header p {
+  color: #334155;
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.app-grid {
+  display: grid;
+  gap: 24px;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(24px);
+  border-radius: 24px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  padding: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 20px;
+  font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+h2 .tag {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  color: #475569;
+  background: rgba(59, 130, 246, 0.12);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+
+.dropzone {
+  border: 2px dashed rgba(59, 130, 246, 0.45);
+  border-radius: 20px;
+  padding: 32px;
+  text-align: center;
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.08), rgba(96, 165, 250, 0.05));
+  color: #1d4ed8;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.dropzone:hover {
+  border-color: rgba(37, 99, 235, 0.75);
+  transform: translateY(-2px);
+}
+
+.dropzone strong {
+  font-size: 1.05rem;
+}
+
+.dropzone span {
+  color: #1e3a8a;
+  font-size: 0.9rem;
+}
+
+.hidden-input {
+  display: none;
+}
+
+.media-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.media-card {
+  position: relative;
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+  border: 1px solid rgba(203, 213, 225, 0.6);
+  display: flex;
+  flex-direction: column;
+}
+
+.media-card img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.media-card textarea {
+  border: none;
+  resize: vertical;
+  min-height: 100px;
+  padding: 16px;
+  font-size: 0.95rem;
+  background: linear-gradient(135deg, rgba(248, 250, 252, 0.9), rgba(241, 245, 249, 0.9));
+  color: #0f172a;
+}
+
+.media-card textarea:focus {
+  outline: 2px solid rgba(59, 130, 246, 0.35);
+}
+
+.media-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: rgba(15, 23, 42, 0.05);
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.remove-button {
+  border: none;
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.85rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.remove-button:hover {
+  background: rgba(239, 68, 68, 0.28);
+  color: #7f1d1d;
+}
+
+.prompt-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.prompt-section textarea {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  padding: 18px;
+  font-size: 1rem;
+  min-height: 120px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.prompt-section textarea:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.65);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.generate-button {
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 14px 28px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.generate-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.generate-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 40px rgba(37, 99, 235, 0.38);
+}
+
+.status-bar {
+  min-height: 24px;
+  color: #1d4ed8;
+  font-weight: 500;
+}
+
+.error-message {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.generated-card {
+  background: white;
+  border-radius: 18px;
+  padding: 16px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(203, 213, 225, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.generated-card img,
+.generated-card video {
+  width: 100%;
+  border-radius: 12px;
+  object-fit: cover;
+  background: #f1f5f9;
+}
+
+.generated-card footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.helper-text {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding: 24px 16px 48px;
+  }
+
+  .card {
+    padding: 22px;
+  }
+
+  .generate-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .actions {
+    justify-content: center;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,352 @@
+import {
+  ChangeEvent,
+  DragEvent,
+  FormEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import "./App.css";
+import { buildApiUrl } from "./lib/api";
+
+type UploadedImage = {
+  id: string;
+  file: File;
+  preview: string;
+  instruction: string;
+  originalName: string;
+};
+
+type GenerationResponse = {
+  output?: string[] | string;
+  status?: string;
+  logs?: string;
+};
+
+const createId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}`;
+};
+
+export default function App() {
+  const [prompt, setPrompt] = useState("");
+  const [negativePrompt, setNegativePrompt] = useState("");
+  const [images, setImages] = useState<UploadedImage[]>([]);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [results, setResults] = useState<string[]>([]);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const hasImages = images.length > 0;
+
+  useEffect(() => {
+    const currentImages = images;
+    return () => {
+      currentImages.forEach((image) => URL.revokeObjectURL(image.preview));
+    };
+  }, [images]);
+
+  const instructionChecklist = useMemo(
+    () =>
+      images.map((image, index) => ({
+        index: index + 1,
+        name: image.originalName,
+        instruction: image.instruction,
+      })),
+    [images]
+  );
+
+  const addFiles = (fileList: FileList | File[]) => {
+    const incoming = Array.from(fileList);
+    if (!incoming.length) return;
+
+    setImages((previous) => {
+      const deduplicated = incoming.filter((file) => {
+        return !previous.some(
+          (existing) =>
+            existing.file.name === file.name &&
+            existing.file.size === file.size &&
+            existing.file.lastModified === file.lastModified
+        );
+      });
+
+      const mapped = deduplicated.map((file) => ({
+        id: createId(),
+        file,
+        originalName: file.name,
+        instruction: "",
+        preview: URL.createObjectURL(file),
+      }));
+
+      return [...previous, ...mapped];
+    });
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files) {
+      addFiles(event.target.files);
+      event.target.value = "";
+    }
+  };
+
+  const handleDrop = (event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+    if (event.dataTransfer.files) {
+      addFiles(event.dataTransfer.files);
+    }
+  };
+
+  const handleDragOver = (event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+  };
+
+  const updateInstruction = (id: string, instruction: string) => {
+    setImages((previous) =>
+      previous.map((item) => (item.id === id ? { ...item, instruction } : item))
+    );
+  };
+
+  const removeImage = (id: string) => {
+    setImages((previous) => {
+      const target = previous.find((image) => image.id === id);
+      if (target) {
+        URL.revokeObjectURL(target.preview);
+      }
+      return previous.filter((image) => image.id !== id);
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!prompt.trim()) {
+      setErrorMessage("Describe the scene you want Seedream to generate.");
+      return;
+    }
+
+    if (!images.length) {
+      setErrorMessage("Add at least one reference image to guide the generation.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    setStatusMessage("Sending your prompt to Seedream…");
+
+    const formData = new FormData();
+    formData.append("prompt", prompt.trim());
+    if (negativePrompt.trim()) {
+      formData.append("negativePrompt", negativePrompt.trim());
+    }
+
+    const instructionsPayload = images.map((image) => ({
+      id: image.id,
+      instruction: image.instruction,
+      originalName: image.originalName,
+    }));
+    formData.append("instructions", JSON.stringify(instructionsPayload));
+
+    images.forEach((image) => {
+      const serverFileName = `${image.id}__${image.originalName}`;
+      formData.append("images", image.file, serverFileName);
+    });
+
+    try {
+      const response = await fetch(buildApiUrl("/api/generate"), {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        let message = "Seedream request failed";
+        try {
+          const payload = (await response.json()) as GenerationResponse;
+          message = payload?.status || (payload as unknown as { error?: string })?.error || message;
+        } catch (error) {
+          // Swallow JSON parse errors and use default message
+        }
+        throw new Error(message);
+      }
+
+      const payload = (await response.json()) as GenerationResponse;
+      const outputData = Array.isArray(payload.output)
+        ? payload.output
+        : payload.output
+        ? [payload.output]
+        : [];
+
+      setResults(outputData);
+      setStatusMessage(payload.status || "Seedream finished rendering");
+    } catch (error) {
+      setResults([]);
+      setStatusMessage("");
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unexpected error. Please try again."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>Seedream Studio</h1>
+        <p>
+          Upload reference photos, tell Seedream what to keep from each one, and craft a
+          prompt to generate your final composition.
+        </p>
+      </header>
+
+      <form className="app-grid" onSubmit={handleSubmit}>
+        <section className="card">
+          <h2>
+            <span className="tag">Step 1</span>
+            Reference images
+          </h2>
+          <label
+            className="dropzone"
+            htmlFor="media-input"
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            onClick={() => inputRef.current?.click()}
+          >
+            <strong>Drop images here or click to browse</strong>
+            <span>Supports PNG, JPG or WEBP up to 10MB each. You can add multiple files.</span>
+            <input
+              ref={inputRef}
+              className="hidden-input"
+              id="media-input"
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleFileChange}
+            />
+          </label>
+
+          {hasImages ? (
+            <div className="media-grid" aria-live="polite">
+              {images.map((image, index) => (
+                <article className="media-card" key={image.id}>
+                  <header>
+                    <span>{`Image ${index + 1}`}</span>
+                    <button
+                      type="button"
+                      className="remove-button"
+                      onClick={() => removeImage(image.id)}
+                    >
+                      Remove
+                    </button>
+                  </header>
+                  <img src={image.preview} alt={image.originalName} />
+                  <textarea
+                    placeholder="Tell Seedream what to borrow from this reference…"
+                    value={image.instruction}
+                    onChange={(event) => updateInstruction(image.id, event.target.value)}
+                  />
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="helper-text">
+              Reference cues can be facial features, clothing, lighting, or composition. Give each
+              image a short note so Seedream knows how to blend them.
+            </p>
+          )}
+        </section>
+
+        <section className="card">
+          <h2>
+            <span className="tag">Step 2</span>
+            Creative brief
+          </h2>
+
+          <div className="prompt-section">
+            <label htmlFor="prompt">
+              <strong>Main prompt</strong>
+            </label>
+            <textarea
+              id="prompt"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Describe the final artwork you want Seedream to create."
+            />
+
+            <label htmlFor="negative-prompt">
+              <strong>Negative prompt</strong>
+            </label>
+            <textarea
+              id="negative-prompt"
+              value={negativePrompt}
+              onChange={(event) => setNegativePrompt(event.target.value)}
+              placeholder="Optional: list any elements Seedream should avoid."
+            />
+          </div>
+
+          <div className="actions">
+            <div className="status-bar" role="status" aria-live="polite">
+              {errorMessage ? <span className="error-message">{errorMessage}</span> : statusMessage}
+            </div>
+            <button className="generate-button" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Generating…" : "Run Seedream"}
+            </button>
+          </div>
+        </section>
+
+        {instructionChecklist.length > 0 && (
+          <section className="card">
+            <h2>
+              <span className="tag">Step 3</span>
+              Instruction checklist
+            </h2>
+            <ul>
+              {instructionChecklist.map((item) => (
+                <li key={item.index}>
+                  <strong>{`Image ${item.index}`}</strong> — {item.name}
+                  {item.instruction ? ` · ${item.instruction}` : " · No guidance added yet"}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {results.length > 0 && (
+          <section className="card">
+            <h2>
+              <span className="tag">Output</span>
+              Generated media
+            </h2>
+            <div className="results-grid">
+              {results.map((item, index) => {
+                const lower = item.toLowerCase();
+                const isVideo = lower.includes(".mp4") || lower.includes("video");
+                const label = `Seedream output ${index + 1}`;
+
+                return (
+                  <div className="generated-card" key={item}>
+                    {isVideo ? (
+                      <video src={item} controls autoPlay loop muted playsInline />
+                    ) : (
+                      <img src={item} alt={label} />
+                    )}
+                    <footer>
+                      <span>{label}</span>
+                      <a href={item} target="_blank" rel="noreferrer">
+                        Open
+                      </a>
+                    </footer>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,27 @@
+:root {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #f1f5ff, #f8fafc 55%);
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font: inherit;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,5 @@
+const baseUrl = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/$/, "");
+
+export const API_BASE_URL = baseUrl.length > 0 ? baseUrl : "";
+
+export const buildApiUrl = (path: string) => `${API_BASE_URL}${path}`;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, loadEnv } from "vite";
+import react from "@vitejs/plugin-react";
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "VITE_");
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      open: false,
+      proxy: env.VITE_API_BASE_URL
+        ? undefined
+        : {
+            "/api": {
+              target: "http://localhost:5000",
+              changeOrigin: true,
+            },
+          },
+    },
+  };
+});

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,12 @@
+# Required: Replicate API token
+REPLICATE_API_TOKEN=your_replicate_token_here
+
+# Required: the fully-qualified model version hash for Seedream-4
+# Example: bytedance/seedream-4:1234567890abcdef...
+SEEDREAM4_MODEL_VERSION=
+
+# Optional: override default server port (default 5000)
+# PORT=5000
+
+# Optional: comma-separated origins allowed by CORS
+# ALLOWED_ORIGINS=http://localhost:5173

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,160 @@
+import cors from "cors";
+import dotenv from "dotenv";
+import express from "express";
+import multer from "multer";
+import Replicate from "replicate";
+
+dotenv.config();
+
+const app = express();
+const port = parseInt(process.env.PORT || "5000", 10);
+
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+app.use(
+  cors({
+    origin: allowedOrigins.length ? allowedOrigins : undefined,
+    credentials: true,
+  })
+);
+app.use(express.json({ limit: "10mb" }));
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    files: 6,
+    fileSize: 10 * 1024 * 1024,
+  },
+});
+
+const ensureReplicate = () => {
+  const token = process.env.REPLICATE_API_TOKEN;
+  if (!token) {
+    throw new Error("REPLICATE_API_TOKEN is not set");
+  }
+
+  return new Replicate({ auth: token });
+};
+
+const resolveInstructions = (raw) => {
+  if (!raw) return [];
+  if (Array.isArray(raw)) {
+    try {
+      return raw.map((entry) => JSON.parse(entry));
+    } catch (error) {
+      console.warn("Unable to parse instruction payload", error);
+      return [];
+    }
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    console.warn("Unable to parse instruction payload", error);
+    return [];
+  }
+};
+
+app.get("/api/health", (_req, res) => {
+  res.json({
+    status: "ok",
+    modelVersion: process.env.SEEDREAM4_MODEL_VERSION || null,
+  });
+});
+
+app.post("/api/generate", upload.array("images"), async (req, res) => {
+  const prompt = (req.body?.prompt || "").toString().trim();
+  const negativePrompt = (req.body?.negativePrompt || "").toString().trim();
+  const instructionsRaw = req.body?.instructions;
+  const files = req.files || [];
+
+  if (!prompt) {
+    return res.status(400).json({ error: "Prompt is required" });
+  }
+
+  if (!files.length) {
+    return res.status(400).json({ error: "At least one reference image is required" });
+  }
+
+  const instructions = resolveInstructions(instructionsRaw);
+
+  const references = files.map((file) => {
+    const fileName = file.originalname || file.fieldname;
+    const [imageId, originalName] = fileName.includes("__")
+      ? fileName.split(/__(.+)/)
+      : [fileName, fileName];
+    const instructionEntry = instructions.find((entry) => entry.id === imageId);
+    const note = instructionEntry?.instruction?.toString().trim() || "";
+
+    return {
+      id: imageId,
+      originalName: instructionEntry?.originalName || originalName,
+      prompt: note,
+      dataUri: `data:${file.mimetype};base64,${file.buffer.toString("base64")}`,
+    };
+  });
+
+  const replicateVersion =
+    process.env.SEEDREAM4_MODEL_VERSION || process.env.SEEDREAM_MODEL_VERSION;
+
+  if (!replicateVersion) {
+    return res
+      .status(500)
+      .json({ error: "Server misconfiguration: missing Seedream model version" });
+  }
+
+  const promptSegments = [prompt];
+  const guidance = references
+    .map((reference, index) =>
+      reference.prompt
+        ? `Image ${index + 1} (${reference.originalName}): ${reference.prompt}`
+        : null
+    )
+    .filter(Boolean);
+
+  if (guidance.length) {
+    promptSegments.push(`Reference guidance:\n${guidance.join("\n")}`);
+  }
+
+  const finalPrompt = promptSegments.join("\n\n");
+
+  try {
+    const replicate = ensureReplicate();
+
+    const inputPayload = {
+      prompt: finalPrompt,
+      reference_images: references.map((reference) => reference.dataUri),
+      reference_prompts: references.map((reference) => reference.prompt),
+    };
+
+    if (negativePrompt) {
+      inputPayload.negative_prompt = negativePrompt;
+    }
+
+    const output = await replicate.run(replicateVersion, {
+      input: inputPayload,
+    });
+
+    res.json({
+      status: "Seedream generation completed",
+      output,
+      prompt: finalPrompt,
+    });
+  } catch (error) {
+    console.error("Seedream generation failed", error);
+    const message =
+      (error?.error?.message ||
+        error?.message ||
+        (typeof error === "string" ? error : null) ||
+        "Unable to reach Replicate") as string;
+
+    res.status(500).json({ error: message });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Seedream server listening on port ${port}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "seedream-server",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "dev": "nodemon index.js",
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1",
+    "replicate": "^0.23.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a Vite + React front-end with multi-image uploads, per-image guidance, prompt composer, and results viewer
- add an Express API proxy that converts uploads into Seedream-friendly prompts and forwards requests via Replicate's SDK
- document project structure, environment requirements, and local development workflow

## Testing
- npm install *(fails: 403 Forbidden from registry)*
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d337df3ba48323a2f1e75dadfbf6cc